### PR TITLE
Handle static files like "css" without statements

### DIFF
--- a/lib/fast-import-js.js
+++ b/lib/fast-import-js.js
@@ -31,6 +31,9 @@ export default {
   getLineToAdd(currentBufferPath, filePath, importSpecifier, importPath) {
     let semicolons = atom.config.get('fast-import-js.semicolons') ? ';' : '';
     let quote = atom.config.get('fast-import-js.quote');
+    if(/\.css|scss|sass|less$/.test(filePath)){
+        return `import ${quote}${importPath}${quote}${semicolons}\n`;
+    }
     return `import ${importSpecifier} from ${quote}${importPath}${quote}${semicolons}\n`;
   },
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fast-import-js",
   "main": "./lib/fast-import-js",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Import helper for javascript in Atom",
   "keywords": [],
   "repository": "https://github.com/alanzanattadev/atom-fast-import-js",


### PR DESCRIPTION
Some file types like css don't use a specifier on import statements, so this change handles this scenario.